### PR TITLE
fix#11: トップページを整理

### DIFF
--- a/backend/app/Http/Controllers/PostController.php
+++ b/backend/app/Http/Controllers/PostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Post;
+use App\Http\Controllers\PostController;
 
 class PostController extends Controller
 {

--- a/backend/resources/views/navigation-menu.blade.php
+++ b/backend/resources/views/navigation-menu.blade.php
@@ -12,9 +12,14 @@
                 </div>
 
                 <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
+                <div class="hidden space-x-8 sm:-my-px sm:ml-20 sm:flex">
                     <x-jet-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                         {{ __('oteireとは') }}
+                    </x-jet-nav-link>
+                </div>
+                <div class="hidden space-x-8 sm:-my-px sm:ml-1 sm:flex">
+                    <x-jet-nav-link href="{{ route('post.index') }}" :active="request()->routeIs('post.index')">
+                        {{ __('投稿一覧') }}
                     </x-jet-nav-link>
                 </div>
             </div>

--- a/backend/resources/views/post/index.blade.php
+++ b/backend/resources/views/post/index.blade.php
@@ -1,5 +1,3 @@
-@extends('layout')
-
 {{-- bladeはphpコードを含むことが出来るテンプレートエンジン --}}
 
   {{-- <div class="uk-container">
@@ -19,30 +17,39 @@
     @endforeach
   </div> --}}
 
-@section('content')
+<x-app-layout>
+  <x-slot name="header">
+    <h1 class="font-semibold text-l text-gray-800 leading-tight">
+        投稿一覧
+    </h1>
+  </x-slot>
   <div>
-    <a href="/posts/create" class="btn">投稿を作成する</a>
+    <div>
+      <a href="/posts/create" class="btn">投稿を作成する</a>
+    </div>
+    <div class="uk-container">
+      {{-- forelse,emptyを使うとデータがからのときの処理もできる --}}
+      @forelse ($posts as $post)
+        <div>
+          {{ $post->id }}
+        </div>
+        <div>
+          {{ $post->updated_at }}
+        </div>
+        <div>
+          {{ $post->title }}
+        </div>
+        <div>
+          {{ $post->content }}
+        </div>
+        <div>
+        <a href="/posts/{{ $post->id }}" class="btn">詳しく見る</a>
+        </div>
+      @empty
+          <div>投稿がありません</div>
+      @endforelse
+    </div>
   </div>
-  <div class="uk-container">
-    {{-- forelse,emptyを使うとデータがからのときの処理もできる --}}
-    @forelse ($posts as $post)
-      <div>
-        {{ $post->id }}
-      </div>
-      <div>
-        {{ $post->updated_at }}
-      </div>
-      <div>
-        {{ $post->title }}
-      </div>
-      <div>
-        {{ $post->content }}
-      </div>
-      <div>
-      <a href="/posts/{{ $post->id }}" class="btn">詳しく見る</a>
-      </div>
-    @empty
-        <div>投稿がありません</div>
-    @endforelse
-  </div>
-@endsection
+</x-app-layout>
+
+{{-- @endsection --}}

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -21,4 +21,4 @@ Route::get('/', function () {
     return view('layouts.app');
 });
 
-Route::resource('posts', 'App\Http\Controllers\PostController');
+Route::resource('/post', 'App\Http\Controllers\PostController');


### PR DESCRIPTION
close #11 

## 修正箇所
- ナビゲーションメニューに投稿一覧項目を追加
- 投稿一覧画面上にナビゲーションが表示されるように変更

## 以下画像にて確認
<img width="1078" alt="スクリーンショット 2021-02-06 19 21 06" src="https://user-images.githubusercontent.com/54735254/107115528-9cda0a00-68b0-11eb-920b-356f8ef42876.png">
